### PR TITLE
AttributeIdentifierInterface::getElementIdentifier() always returns ElementIdentifierInterface

### DIFF
--- a/src/Identifier/AttributeIdentifier.php
+++ b/src/Identifier/AttributeIdentifier.php
@@ -17,7 +17,7 @@ class AttributeIdentifier extends Identifier implements AttributeIdentifierInter
         $this->attributeName = $attributeName;
     }
 
-    public function getElementIdentifier(): ?ElementIdentifierInterface
+    public function getElementIdentifier(): ElementIdentifierInterface
     {
         return $this->identifier;
     }

--- a/src/Identifier/AttributeIdentifierInterface.php
+++ b/src/Identifier/AttributeIdentifierInterface.php
@@ -4,6 +4,6 @@ namespace webignition\BasilModel\Identifier;
 
 interface AttributeIdentifierInterface extends IdentifierInterface
 {
-    public function getElementIdentifier(): ?ElementIdentifierInterface;
+    public function getElementIdentifier(): ElementIdentifierInterface;
     public function getAttributeName(): ?string;
 }


### PR DESCRIPTION
Fixes #174